### PR TITLE
Allow passing ReactSelect props

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ data = {
 | placeholder | `String` | `select` placeholder text' |
 | noOptionsMessage | `String` | Fallback text for empty `select` options |
 
+You can also pass any other [`ReactSelect`](https://github.com/JedWatson/react-select) prop to `select` fields, such as `menuIsOpen`.
+
 ## Method props
 
 ```jsx

--- a/src/lib/Fields/SelectField.js
+++ b/src/lib/Fields/SelectField.js
@@ -7,20 +7,21 @@ const SelectField = props => {
     onChanges,
     error,
     item: {
-      name,
-      options,
-      placeholder,
+      component,
+      field,
+      label,
+      validate,
       noOptionsMessage,
+      ...rest,
     }
   } = props
+
   return (
     <Select
+      {...rest}
       className={`gsd-form-select-wrap ${error ? 'gsd-form-error' : ''}`}
       classNamePrefix="gsd-form-select"
-      placeholder={placeholder}
       noOptionsMessage={() => noOptionsMessage}
-      name={name}
-      options={options}
       value={value}
       onChange={e => onChanges(e)}
     />


### PR DESCRIPTION
The `select` input component now allows for the user to pass props to 
the underlying ReactSelect component, such as menuIsOpen.