### PR TITLE
Use value only in select inputs

### DIFF
--- a/src/lib/Fields/SelectField.js
+++ b/src/lib/Fields/SelectField.js
@@ -1,31 +1,49 @@
-import React from 'react'
+import React, { Component } from 'react'
 import Select from 'react-select'
 
-const SelectField = props => {
-  const {
-    value,
-    onChanges,
-    error,
-    item: {
-      component,
-      field,
-      label,
-      validate,
-      noOptionsMessage,
-      ...rest,
+class SelectField extends Component {
+  constructor (props) {
+    super(props)
+    const { item } = props
+    if (item.useObject) {
+      this.getValue = value => value
+      this.valueChange = option => option
+    } else {
+      this.getValue = (value, options) =>
+        options.find(option => option.value === value) || null
+      this.valueChange = option => option.value
     }
-  } = props
+  }
 
-  return (
-    <Select
-      {...rest}
-      className={`gsd-form-select-wrap ${error ? 'gsd-form-error' : ''}`}
-      classNamePrefix="gsd-form-select"
-      noOptionsMessage={() => noOptionsMessage}
-      value={value}
-      onChange={e => onChanges(e)}
-    />
-  )
+  render () {
+    const {
+      value,
+      onChanges,
+      error,
+      item: {
+        component,
+        field,
+        label,
+        validate,
+        noOptionsMessage,
+        options,
+        useObject,
+        ...rest,
+      }
+    } = this.props
+
+    return (
+      <Select
+        {...rest}
+        options={options}
+        className={`gsd-form-select-wrap ${error ? 'gsd-form-error' : ''}`}
+        classNamePrefix="gsd-form-select"
+        noOptionsMessage={() => noOptionsMessage}
+        value={this.getValue(value, options)}
+        onChange={e => onChanges(this.valueChange(e))}
+      />
+    )
+  }
 }
 
 export default SelectField


### PR DESCRIPTION
Due to ReactSelect's own setup, the whole value/label object was 
returned/used as the input value. Since it's way more common to have the 
value itself only (and the label is obtainable via options array), 
select inputs now work as such.