### PR TITLE
Allow controlling fields dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Formik-based React library to create forms from plain JS objects (or JSON!)
 
-[Demo](https://codesandbox.io/s/zlrmp3o77l)
+## Demo
+
+[Single fields object](https://codesandbox.io/s/zlrmp3o77l)
+[Multiple field sets](https://codesandbox.io/s/y3wxvk3lyv)
 
 ## Installing
 
@@ -112,6 +115,10 @@ for example.
 
 You can use the `handleChanges` prop to, for example, change the available
 options for interdependent `select` inputs, such as country/state/city.
+
+Another useful `GsdForm` prop is `values`, which can be used to pass dynamic
+values to Formik and make whatever desired inputs fully controlled by your
+parent component.
 
 ## Dependencies
 

--- a/src/AppForm.js
+++ b/src/AppForm.js
@@ -103,9 +103,12 @@ class App extends Component {
         ...json,
         form: {
           ...json.form,
-          country: {
-            ...json.form.country,
-            options: country
+          fields: {
+            ...json.form.fields,
+            country: {
+              ...json.form.fields.country,
+              options: country
+            }
           }
         }
       }
@@ -114,7 +117,7 @@ class App extends Component {
 
   setStatesByCountry (value) {
     const states = locale
-      .filter(item => value.label ? item.countryName === value.label : true)
+      .filter(item => item.countryShortCode === value)
       .reduce((acc, item) => item.regions.map(item => ({
         value: item.shortCode,
         label: item.name,
@@ -126,9 +129,12 @@ class App extends Component {
         ...prevState.data,
         form: {
           ...prevState.data.form,
-          state: {
-            ...prevState.data.form.state,
-            options: states
+          fields: {
+            ...prevState.data.form.fields,
+            state: {
+              ...prevState.data.form.fields.state,
+              options: states
+            }
           }
         }
       }


### PR DESCRIPTION
An additional prop "values" was added in order to allow fully controlled 
inputs from outside GsdForm, which is useful in cases where manually 
changing those inputs is necessary but enableReinitialize isn't the 
wanted solution (mostly because it fully resets the form).